### PR TITLE
Gateway support for NCS 1.4

### DIFF
--- a/include/net/cloud.h
+++ b/include/net/cloud.h
@@ -403,15 +403,17 @@ static inline int cloud_user_data_set(struct cloud_backend *const backend,
 
 /**@brief Get the id string for the current device.
  *
- * @param backend   Pointer to cloud backend structure.
- * @param user_data Pointer to user defined data that will be passed on as
- * 		       argument to cloud event handler.
+ * @param backend	Pointer to cloud backend structure.
+ * @param id		Pointer to buffer to receive ID.
+ * @param id_len	Size of buffer.
+ * @return 0 on success otherwise error number.
  */
 static inline int cloud_get_id(const struct cloud_backend *const backend,
 		      char *id, size_t id_len)
 {
 	if (backend == NULL || backend->api == NULL ||
-	    backend->api->get_id == NULL) {
+	    backend->api->get_id == NULL || id == NULL ||
+	    id_len == 0) {
 		return -ENOTSUP;
 	}
 

--- a/include/net/cloud.h
+++ b/include/net/cloud.h
@@ -171,6 +171,8 @@ struct cloud_api {
 				size_t list_count);
 	int (*user_data_set)(const struct cloud_backend *const backend,
 			     void *user_data);
+	int (*get_id)(const struct cloud_backend *const backend,
+		      char *id, size_t id_len);
 };
 
 /**@brief Structure for cloud backend configuration. */
@@ -397,6 +399,23 @@ static inline int cloud_user_data_set(struct cloud_backend *const backend,
 	}
 
 	return backend->api->user_data_set(backend, user_data);
+}
+
+/**@brief Get the id string for the current device.
+ *
+ * @param backend   Pointer to cloud backend structure.
+ * @param user_data Pointer to user defined data that will be passed on as
+ * 		       argument to cloud event handler.
+ */
+static inline int cloud_get_id(const struct cloud_backend *const backend,
+		      char *id, size_t id_len)
+{
+	if (backend == NULL || backend->api == NULL ||
+	    backend->api->get_id == NULL) {
+		return -ENOTSUP;
+	}
+
+	return backend->api->get_id(backend, id, id_len);
 }
 
 /**

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -50,7 +50,7 @@ struct nct_cc_data {
 
 struct nct_gw_data {
 	struct nrf_cloud_data data;
-	u32_t id;
+	uint32_t id;
 };
 
 struct nct_evt {

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -7,6 +7,7 @@
 #ifndef NRF_CLOUD_TRANSPORT_H__
 #define NRF_CLOUD_TRANSPORT_H__
 
+#include <stddef.h>
 #include <net/nrf_cloud.h>
 
 #ifdef __cplusplus
@@ -127,6 +128,9 @@ int nct_keepalive_time_left(void);
 
 /**@brief Input from the cloud module. */
 int nct_input(const struct nct_evt *evt);
+
+/**@brief Retrieve the device id. */
+int nct_client_id_get(char *id, size_t id_len);
 
 /**@brief Signal to apply FOTA update. */
 void nct_apply_update(void);

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -139,7 +139,8 @@ void nct_apply_update(void);
 #ifdef CONFIG_APR_GATEWAY
 void g2c_send(char* buffer);
 void shadow_publish(char* buffer);
-void nct_gw_subscribe(char* c2g_topic_str);
+int nct_gw_subscribe(char* c2g_topic_str);
+int nct_gw_connect(void);
 void set_gw_rx_topic(char* topic_prefix);
 void set_gw_tx_topic(char* topic_prefix);
 #endif

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -47,6 +47,11 @@ struct nct_cc_data {
 	enum nct_cc_opcode opcode;
 };
 
+struct nct_gw_data {
+	struct nrf_cloud_data data;
+	u32_t id;
+};
+
 struct nct_evt {
 	int32_t status;
 	union {
@@ -125,6 +130,15 @@ int nct_input(const struct nct_evt *evt);
 
 /**@brief Signal to apply FOTA update. */
 void nct_apply_update(void);
+
+
+#ifdef CONFIG_APR_GATEWAY
+void g2c_send(char* buffer);
+void shadow_publish(char* buffer);
+void nct_gw_subscribe(char* c2g_topic_str);
+void set_gw_rx_topic(char* topic_prefix);
+void set_gw_tx_topic(char* topic_prefix);
+#endif
 
 #ifdef __cplusplus
 }

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -136,7 +136,7 @@ int nct_client_id_get(char *id, size_t id_len);
 void nct_apply_update(void);
 
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 void g2c_send(char* buffer);
 void shadow_publish(char* buffer);
 int nct_gw_subscribe(char* c2g_topic_str);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -498,6 +498,12 @@ static int api_user_data_set(const struct cloud_backend *const backend,
 	return 0;
 }
 
+static int api_get_id(const struct cloud_backend *const backend,
+		      char *id, size_t id_len)
+{
+	return nct_client_id_get(id, id_len);
+}
+
 void nrf_cloud_run(void)
 {
 	int ret;
@@ -618,7 +624,8 @@ static const struct cloud_api nrf_cloud_api = {
 	.ping = api_ping,
 	.keepalive_time_left = api_keepalive_time_left,
 	.input = api_input,
-	.user_data_set = api_user_data_set
+	.user_data_set = api_user_data_set,
+	.get_id = api_get_id
 };
 
 CLOUD_BACKEND_DEFINE(NRF_CLOUD, nrf_cloud_api);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -422,13 +422,16 @@ int nrf_cloud_encode_state(uint32_t reported_state, struct nrf_cloud_data *outpu
 	cJSON *state_obj = cJSON_CreateObject();
 	cJSON *reported_obj = cJSON_CreateObject();
 	cJSON *pairing_obj = cJSON_CreateObject();
+	cJSON *connection_obj = cJSON_CreateObject();
 
 	if ((root_obj == NULL) || (state_obj == NULL) ||
-	    (reported_obj == NULL) || (pairing_obj == NULL)) {
+	    (reported_obj == NULL) || (pairing_obj == NULL) ||
+	    (connection_obj == NULL)) {
 		cJSON_Delete(root_obj);
 		cJSON_Delete(state_obj);
 		cJSON_Delete(reported_obj);
 		cJSON_Delete(pairing_obj);
+		cJSON_Delete(connection_obj);
 
 		return -ENOMEM;
 	}
@@ -459,6 +462,12 @@ int nrf_cloud_encode_state(uint32_t reported_state, struct nrf_cloud_data *outpu
 		ret += json_add_str(pairing_obj, "state", PAIRED_STR);
 		ret += json_add_null(pairing_obj, "config");
 		ret += json_add_null(reported_obj, "pairingStatus");
+
+		/* Report keepalive value. */
+		if (cJSON_AddNumberToObject(connection_obj, "keepalive",
+					    CONFIG_MQTT_KEEPALIVE) == NULL) {
+			ret = -ENOMEM;
+		}
 
 		/* Report pairing topics. */
 		cJSON *topics_obj = cJSON_CreateObject();
@@ -491,6 +500,7 @@ int nrf_cloud_encode_state(uint32_t reported_state, struct nrf_cloud_data *outpu
 	}
 
 	ret += json_add_obj(reported_obj, "pairing", pairing_obj);
+	ret += json_add_obj(reported_obj, "connection", connection_obj);
 	ret += json_add_obj(state_obj, "reported", reported_obj);
 	ret += json_add_obj(root_obj, "state", state_obj);
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -14,7 +14,7 @@
 #include "cJSON.h"
 #include "cJSON_os.h"
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 #include "gateway.h"
 #include "ble_conn_mgr.h"
 #endif
@@ -202,7 +202,7 @@ int nrf_cloud_encode_sensor_data(const struct nrf_cloud_sensor_data *sensor,
 	return 0;
 }
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 int nrf_cloud_decode_gateway_state(const char *input_ptr,
 				   cJSON *root_obj)
 {
@@ -279,7 +279,7 @@ int nrf_cloud_decode_requested_state(const struct nrf_cloud_data *input,
 		return -ENOENT;
 	}
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 	int ret = nrf_cloud_decode_gateway_state(input->ptr, root_obj);
 	if (ret != 0) {
 		LOG_ERR("Error from nrf_cloud_decode_gateway_state(): %d", ret);
@@ -293,7 +293,7 @@ int nrf_cloud_decode_requested_state(const struct nrf_cloud_data *input,
 		json_object_decode(desired_obj, "nrfcloud_mqtt_topic_prefix");
 	if (topic_prefix_obj != NULL) {
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 		set_gw_rx_topic(topic_prefix_obj->valuestring);
 		set_gw_tx_topic(topic_prefix_obj->valuestring);
 #endif
@@ -306,7 +306,7 @@ int nrf_cloud_decode_requested_state(const struct nrf_cloud_data *input,
 	pairing_state_obj = json_object_decode(pairing_obj, "state");
 
 	if (!pairing_state_obj || pairing_state_obj->type != cJSON_String) {
-#ifndef CONFIG_APR_GATEWAY
+#ifndef CONFIG_NRF_CLOUD_GATEWAY
 		if (cJSON_HasObjectItem(desired_obj, "config") == false) {
 			LOG_WRN("Unhandled data received from nRF Cloud.");
 			LOG_INF("Ensure device firmware is up to date.");

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -14,6 +14,11 @@
 #include "cJSON.h"
 #include "cJSON_os.h"
 
+#ifdef CONFIG_APR_GATEWAY
+#include "gateway.h"
+#include "ble_conn_mgr.h"
+#endif
+
 LOG_MODULE_REGISTER(nrf_cloud_codec, CONFIG_NRF_CLOUD_LOG_LEVEL);
 
 #define DUA_PIN_STR "not_associated"
@@ -197,6 +202,62 @@ int nrf_cloud_encode_sensor_data(const struct nrf_cloud_sensor_data *sensor,
 	return 0;
 }
 
+#ifdef CONFIG_APR_GATEWAY
+int nrf_cloud_decode_gateway_state(const char *input_ptr,
+				   cJSON *root_obj)
+{
+	cJSON *state_obj;
+	cJSON *desired_connections_obj;
+	cJSON *item;
+	cJSON *address_obj;
+	cJSON *ble_address;
+	cJSON *ble_address_type;
+	int ret = 0;
+
+	state_obj = json_object_decode(root_obj, "state");
+	if (state_obj == NULL) {
+		goto done;
+	}
+
+	desired_connections_obj = json_object_decode(state_obj,
+						  "desiredConnections");
+	if(desired_connections_obj == NULL) {
+		goto done;
+	}
+
+	LOG_DBG("gateway state change detected: %s", log_strdup(input_ptr));
+	ble_conn_mgr_clear_desired();
+
+	for (int i = 0; i < cJSON_GetArraySize(desired_connections_obj); i++) {
+		item = cJSON_GetArrayItem(desired_connections_obj, i);
+		address_obj = cJSON_GetObjectItem(item, "address");
+		ble_address = cJSON_GetObjectItem(address_obj, "address");
+		ble_address_type = cJSON_GetObjectItem(address_obj, "type");
+
+		if ((ble_address != NULL) && (ble_address_type != NULL)) {
+			LOG_DBG("Desired BLE address: %s",
+				ble_address->valuestring);
+			LOG_DBG("Desired BLE address type: %s",
+				ble_address_type->valuestring);
+
+			if (ble_conn_mgr_add_conn(ble_address->valuestring,
+			       ble_address_type->valuestring)) {
+				LOG_DBG("Conn already added");
+			}
+			ble_conn_mgr_update_desired(ble_address->valuestring,
+						    i);
+		} else {
+			LOG_ERR("invalid desired connection");
+		}
+	}
+
+	ble_conn_mgr_update_connections();
+
+done:
+	return ret;
+}
+#endif
+
 int nrf_cloud_decode_requested_state(const struct nrf_cloud_data *input,
 				     enum nfsm_state *requested_state)
 {
@@ -218,11 +279,23 @@ int nrf_cloud_decode_requested_state(const struct nrf_cloud_data *input,
 		return -ENOENT;
 	}
 
+#ifdef CONFIG_APR_GATEWAY
+	int ret = nrf_cloud_decode_gateway_state(input->ptr, root_obj);
+	if (ret != 0) {
+		return ret;
+	}
+#endif
+
 	nrf_cloud_decode_desired_obj(root_obj, &desired_obj);
 
 	topic_prefix_obj =
 		json_object_decode(desired_obj, "nrfcloud_mqtt_topic_prefix");
 	if (topic_prefix_obj != NULL) {
+
+#ifdef CONFIG_APR_GATEWAY
+		set_gw_rx_topic(topic_prefix_obj->valuestring);
+		set_gw_tx_topic(topic_prefix_obj->valuestring);
+#endif
 		(*requested_state) = STATE_UA_PIN_COMPLETE;
 		cJSON_Delete(root_obj);
 		return 0;
@@ -246,7 +319,8 @@ int nrf_cloud_decode_requested_state(const struct nrf_cloud_data *input,
 	if (compare(state_str, DUA_PIN_STR)) {
 		(*requested_state) = STATE_UA_PIN_WAIT;
 	} else {
-		LOG_ERR("Deprecated state. Delete device from nRF Cloud and update device with JITP certificates.");
+		LOG_ERR("Deprecated state. Delete device from nrfCloud and "
+			"update device with JITP certificates.");
 		cJSON_Delete(root_obj);
 		return -ENOTSUP;
 	}

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -214,13 +214,13 @@ int nrf_cloud_decode_gateway_state(const char *input_ptr,
 
 	state_obj = json_object_decode(root_obj, "state");
 	if (state_obj == NULL) {
-		return -EINVAL;
+		return 0;
 	}
 
 	desired_connections_obj = json_object_decode(state_obj,
 						  "desiredConnections");
 	if(desired_connections_obj == NULL) {
-		return -EINVAL;
+		return 0;
 	}
 
 	LOG_DBG("gateway state change detected: %s", log_strdup(input_ptr));
@@ -282,6 +282,7 @@ int nrf_cloud_decode_requested_state(const struct nrf_cloud_data *input,
 #ifdef CONFIG_APR_GATEWAY
 	int ret = nrf_cloud_decode_gateway_state(input->ptr, root_obj);
 	if (ret != 0) {
+		LOG_ERR("Error from nrf_cloud_decode_gateway_state(): %d", ret);
 		return ret;
 	}
 #endif
@@ -321,8 +322,7 @@ int nrf_cloud_decode_requested_state(const struct nrf_cloud_data *input,
 	if (compare(state_str, DUA_PIN_STR)) {
 		(*requested_state) = STATE_UA_PIN_WAIT;
 	} else {
-		LOG_ERR("Deprecated state. Delete device from nRF Cloud and "
-			"update device with JITP certificates.");
+		LOG_ERR("Deprecated state. Delete device from nRF Cloud and update device with JITP certificates.");
 		cJSON_Delete(root_obj);
 		return -ENOTSUP;
 	}

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -459,9 +459,21 @@ static int cc_tx_ack_handler(const struct nct_evt *nct_evt)
 #else
 		struct nct_evt nevt = { .type = NCT_EVT_DC_CONNECTED,
 					.status = 0 };
+		int err;
 
-		LOG_INF("gateway: skipping nct_dc_connect()");
-		nfsm_handle_incoming_event(&nevt, STATE_DC_CONNECTING);
+		if (!persistent_session) {
+			LOG_INF("Subscribing to c2g topic");
+			err = nct_gw_connect();
+			if (err) {
+				return err;
+			}
+			nfsm_set_current_state_and_notify(STATE_DC_CONNECTING,
+							  NULL);
+		} else {
+			LOG_DBG("Previous session valid;"
+				" skipping nct_gw_connect()");
+			nfsm_handle_incoming_event(&nevt, STATE_DC_CONNECTING);
+		}
 #endif
 	}
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -430,6 +430,8 @@ static int cc_rx_data_handler(const struct nct_evt *nct_evt)
 
 static int cc_tx_ack_handler(const struct nct_evt *nct_evt)
 {
+	int err;
+
 	if (nct_evt->param.data_id == CLOUD_STATE_REQ_ID) {
 		nfsm_set_current_state_and_notify(STATE_CLOUD_STATE_REQUESTED,
 						  NULL);
@@ -438,8 +440,6 @@ static int cc_tx_ack_handler(const struct nct_evt *nct_evt)
 
 	if (nct_evt->param.data_id == PAIRING_STATUS_REPORT_ID) {
 #ifndef CONFIG_APR_GATEWAY
-		int err;
-
 		if (!persistent_session) {
 			err = nct_dc_connect();
 			if (err) {
@@ -459,7 +459,6 @@ static int cc_tx_ack_handler(const struct nct_evt *nct_evt)
 #else
 		struct nct_evt nevt = { .type = NCT_EVT_DC_CONNECTED,
 					.status = 0 };
-		int err;
 
 		if (!persistent_session) {
 			LOG_INF("Subscribing to c2g topic");

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -392,7 +392,7 @@ static int cc_rx_data_handler(const struct nct_evt *nct_evt)
 	err = nrf_cloud_decode_requested_state(payload, &new_state);
 
 	if (err) {
-#ifndef CONFIG_APR_GATEWAY
+#ifndef CONFIG_NRF_CLOUD_GATEWAY
 		if (!config_found) {
 			LOG_ERR("nrf_cloud_decode_requested_state Failed %d",
 				err);
@@ -439,7 +439,7 @@ static int cc_tx_ack_handler(const struct nct_evt *nct_evt)
 	}
 
 	if (nct_evt->param.data_id == PAIRING_STATUS_REPORT_ID) {
-#ifndef CONFIG_APR_GATEWAY
+#ifndef CONFIG_NRF_CLOUD_GATEWAY
 		if (!persistent_session) {
 			err = nct_dc_connect();
 			if (err) {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -17,7 +17,7 @@
 #include <sys/util.h>
 #include <settings/settings.h>
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 #include "gateway.h"
 #endif
 
@@ -45,7 +45,7 @@ LOG_MODULE_REGISTER(nrf_cloud_transport, CONFIG_NRF_CLOUD_LOG_LEVEL);
 #define NRF_CLOUD_CLIENT_ID_LEN (sizeof(NRF_CLOUD_CLIENT_ID) - 1)
 #endif
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 #undef NRF_CLOUD_CLIENT_ID_LEN
 #define NRF_CLOUD_CLIENT_ID_LEN  10
 #define AT_CMNG_READ_LEN 97
@@ -90,7 +90,7 @@ LOG_MODULE_REGISTER(nrf_cloud_transport, CONFIG_NRF_CLOUD_LOG_LEVEL);
 #define NCT_SHADOW_GET AWS "%s/shadow/get"
 #define NCT_SHADOW_GET_LEN (AWS_LEN + NRF_CLOUD_CLIENT_ID_LEN + 11)
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 #define GET_PSK_ID "AT%CMNG=2,16842753,4"
 #define GET_PSK_ID_LEN (sizeof(GET_PSK_ID)-1)
 #define GET_PSK_ID_ERR "ERROR"
@@ -295,7 +295,7 @@ static uint32_t dc_send(const struct nct_dc_data *dc_data, uint8_t qos)
 	return mqtt_publish(&nct.client, &publish);
 }
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 void shadow_publish(char* buffer)
 {
 	struct mqtt_publish_param publish = {
@@ -389,7 +389,7 @@ static bool strings_compare(const char *s1, const char *s2, uint32_t s1_len,
 	return (strncmp(s1, s2, MIN(s1_len, s2_len))) ? false : true;
 }
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 /* Verify if the topic is a gw topic or not. */
 static bool gw_topic_match(const struct mqtt_topic *topic)
 {
@@ -431,7 +431,7 @@ static bool control_channel_topic_match(uint32_t list_id,
 	return false;
 }
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 static void gw_client_id_get(int at_socket_fd, char *id, size_t id_len)
 {
 	char psk_buf[100];
@@ -497,7 +497,7 @@ int nct_client_id_get(char *id, size_t id_len)
 	at_socket_fd = nrf_socket(NRF_AF_LTE, NRF_SOCK_DGRAM, NRF_PROTO_AT);
 	__ASSERT_NO_MSG(at_socket_fd >= 0);
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 	gw_client_id_get(at_socket_fd, id, id_len);
 #else
 	char imei_buf[NRF_IMEI_LEN + 1];
@@ -965,7 +965,7 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 	struct nct_dc_data dc;
 	bool event_notify = false;
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 	/* TODO: resolve this in a better way, like by passing handler in
 	 * through a structure element
 	 */
@@ -1039,7 +1039,7 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 			evt.type = NCT_EVT_CC_RX_DATA;
 			evt.param.cc = &cc;
 			event_notify = true;
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 		} else if (gw_topic_match(&p->message.topic)) {
 			gw.id = p->message_id;
 			gw.data.ptr = nct.payload_buf;
@@ -1092,7 +1092,7 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 					err);
 			}
 		}
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 		if (_mqtt_evt->param.suback.message_id == NCT_CG_SUBSCRIBE_ID) {
 			evt.type = NCT_EVT_DC_CONNECTED;
 			event_notify = true;
@@ -1145,7 +1145,7 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 		}
 	}
 
-#ifdef CONFIG_APR_GATEWAY
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
 	else if (gateway_notify) {
 		err = gateway_handler(&gw);
 		if (err != 0) {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -380,8 +380,8 @@ void set_gw_tx_topic(char* topic_prefix)
 }
 #endif
 
-static bool strings_compare(const char *s1, const char *s2, u32_t s1_len,
-			    u32_t s2_len)
+static bool strings_compare(const char *s1, const char *s2, uint32_t s1_len,
+			    uint32_t s2_len)
 {
 	return (strncmp(s1, s2, MIN(s1_len, s2_len))) ? false : true;
 }
@@ -958,7 +958,7 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 	/* TODO: resolve this in a better way, like by passing handler in
 	 * through a structure element
 	 */
-	extern u8_t gateway_handler(const struct nct_gw_data *gw_data);
+	extern uint8_t gateway_handler(const struct nct_gw_data *gw_data);
 	struct nct_gw_data gw;
 	bool gateway_notify = false;
 #endif

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -429,7 +429,7 @@ static bool control_channel_topic_match(uint32_t list_id,
 }
 
 /* Function to get the client id */
-static int nct_client_id_get(char *id)
+int nct_client_id_get(char *id, size_t id_len)
 {
 #if !defined(NRF_CLOUD_CLIENT_ID)
 #if defined(CONFIG_BSD_LIBRARY)
@@ -490,7 +490,7 @@ static int nct_client_id_get(char *id)
 		}
 		printk("Gateway ID:%s\n", gateway_id);
 
-		snprintf(id, NRF_CLOUD_CLIENT_ID_LEN + 1, "%s", gateway_id);
+		snprintf(id, id_len, "%s", gateway_id);
 	}
 #else
 	bytes_written = nrf_write(at_socket_fd, "AT+CGSN", 7);
@@ -500,7 +500,7 @@ static int nct_client_id_get(char *id)
 	__ASSERT_NO_MSG(bytes_read == NRF_IMEI_LEN);
 	imei_buf[NRF_IMEI_LEN] = 0;
 
-	snprintf(id, NRF_CLOUD_CLIENT_ID_LEN + 1, "%s%s", CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX, imei_buf);
+	snprintf(id, id_len, "%s%s", CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX, imei_buf);
 #endif
 
 	ret = nrf_close(at_socket_fd);
@@ -509,7 +509,7 @@ static int nct_client_id_get(char *id)
 #error Missing NRF_CLOUD_CLIENT_ID
 #endif /* defined(CONFIG_BSD_LIBRARY) */
 #else
-	memcpy(id, NRF_CLOUD_CLIENT_ID, NRF_CLOUD_CLIENT_ID_LEN + 1);
+	memcpy(id, NRF_CLOUD_CLIENT_ID, id_len);
 #endif /* !defined(NRF_CLOUD_CLIENT_ID) */
 
 	LOG_INF("client_id = %s", log_strdup(id));
@@ -521,7 +521,7 @@ static int nct_topics_populate(void)
 {
 	int ret;
 
-	ret = nct_client_id_get(client_id_buf);
+	ret = nct_client_id_get(client_id_buf, sizeof(client_id_buf));
 	if (ret != 0) {
 		return ret;
 	}

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -17,6 +17,10 @@
 #include <sys/util.h>
 #include <settings/settings.h>
 
+#ifdef CONFIG_APR_GATEWAY
+#include "gateway.h"
+#endif
+
 #if defined(CONFIG_BSD_LIBRARY)
 #include <nrf_socket.h>
 #endif
@@ -39,6 +43,12 @@ LOG_MODULE_REGISTER(nrf_cloud_transport, CONFIG_NRF_CLOUD_LOG_LEVEL);
 #define NRF_CLOUD_CLIENT_ID_LEN (sizeof(CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX) - 1 + NRF_IMEI_LEN)
 #else
 #define NRF_CLOUD_CLIENT_ID_LEN (sizeof(NRF_CLOUD_CLIENT_ID) - 1)
+#endif
+
+#ifdef CONFIG_APR_GATEWAY
+#undef NRF_CLOUD_CLIENT_ID_LEN
+#define NRF_CLOUD_CLIENT_ID_LEN  10
+#define At_CMNG_READ_LEN 97
 #endif
 
 #define NRF_CLOUD_HOSTNAME CONFIG_NRF_CLOUD_HOST_NAME
@@ -79,6 +89,19 @@ LOG_MODULE_REGISTER(nrf_cloud_transport, CONFIG_NRF_CLOUD_LOG_LEVEL);
 
 #define NCT_SHADOW_GET AWS "%s/shadow/get"
 #define NCT_SHADOW_GET_LEN (AWS_LEN + NRF_CLOUD_CLIENT_ID_LEN + 11)
+
+#ifdef CONFIG_APR_GATEWAY
+#define GET_PSK_ID "AT%CMNG=2,16842753,4"
+#define GET_PSK_ID_LEN (sizeof(GET_PSK_ID)-1)
+#define GET_PSK_ID_ERR "ERROR"
+#define GW_TOPIC_STR_LEN 13
+#define MAX_GW_TOPIC_LEN 256
+uint8_t nct_c2g_topic_len = 0;
+char nct_c2g_topic_buf[MAX_GW_TOPIC_LEN];
+uint8_t nct_g2c_topic_len = 0;
+char nct_g2c_topic_buf[MAX_GW_TOPIC_LEN];
+char gateway_id[NRF_CLOUD_CLIENT_ID_LEN+1];
+#endif
 
 /* Buffer for keeping the client_id + \0 */
 static char client_id_buf[NRF_CLOUD_CLIENT_ID_LEN + 1];
@@ -271,11 +294,110 @@ static uint32_t dc_send(const struct nct_dc_data *dc_data, uint8_t qos)
 	return mqtt_publish(&nct.client, &publish);
 }
 
-static bool strings_compare(const char *s1, const char *s2, uint32_t s1_len,
-			    uint32_t s2_len)
+#ifdef CONFIG_APR_GATEWAY
+void shadow_publish(char* buffer)
+{
+	struct mqtt_publish_param publish = {
+		.message.topic.qos = 1,
+		.message.topic.topic.size = NCT_UPDATE_TOPIC_LEN,
+		.message.topic.topic.utf8 = update_topic,
+		.message.payload.data = buffer,
+		.message.payload.len = strlen(buffer),
+		.message_id = dc_get_next_message_id()
+	};
+
+	mqtt_publish(&nct.client, &publish);
+}
+
+
+void g2c_send(char* buffer)
+{
+	if (!nct_g2c_topic_len) {
+		return;
+	}
+
+	struct mqtt_publish_param publish = {
+		.message.topic.qos = 1,
+		.message.topic.topic.size = nct_g2c_topic_len,
+		.message.topic.topic.utf8 = nct_g2c_topic_buf,
+		.message.payload.data = buffer,
+		.message.payload.len = strlen(buffer),
+		.message_id = dc_get_next_message_id()
+	};
+
+	mqtt_publish(&nct.client, &publish);
+}
+
+void nct_gw_subscribe(char* c2g_topic_str)
+{
+   struct mqtt_topic c2g_topic = {
+	.topic = {
+		.utf8 = c2g_topic_str,
+		.size = nct_c2g_topic_len
+	},
+	.qos = MQTT_QOS_1_AT_LEAST_ONCE
+  };
+
+  LOG_DBG("nct_gw_subscribe");
+
+  const struct mqtt_subscription_list subscription_list = {
+	  .list = &c2g_topic,
+	  .list_count = 1,
+	  .message_id = NCT_CC_SUBSCRIBE_ID
+  };
+
+  mqtt_subscribe(&nct.client, &subscription_list);
+
+}
+
+void set_gw_rx_topic(char* topic_prefix)
+{
+	nct_c2g_topic_len = snprintf(nct_c2g_topic_buf, MAX_GW_TOPIC_LEN,
+				 "%sgateways/%s/c2g", topic_prefix, gateway_id);
+
+	if ((nct_c2g_topic_len > 0) && (nct_c2g_topic_len < MAX_GW_TOPIC_LEN)) {
+		LOG_INF("Gateway RX Topic: %s Len: %d", nct_c2g_topic_buf,
+			nct_c2g_topic_len);
+		nct_gw_subscribe(nct_c2g_topic_buf);
+	} else {
+		LOG_ERR("Gateway RX Topic not set");
+		nct_c2g_topic_len = 0;
+	}
+}
+
+void set_gw_tx_topic(char* topic_prefix)
+{
+	nct_g2c_topic_len = snprintf(nct_g2c_topic_buf, MAX_GW_TOPIC_LEN,
+				 "%sgateways/%s/g2c", topic_prefix, gateway_id);
+
+	if ((nct_g2c_topic_len > 0) && (nct_g2c_topic_len < MAX_GW_TOPIC_LEN)) {
+		LOG_INF("Gateway TX Topic: %s Len: %d", nct_g2c_topic_buf,
+			nct_g2c_topic_len);
+	} else {
+		LOG_ERR("Gateway TX Topic not set");
+		nct_g2c_topic_len = 0;
+	}
+}
+#endif
+
+static bool strings_compare(const char *s1, const char *s2, u32_t s1_len,
+			    u32_t s2_len)
 {
 	return (strncmp(s1, s2, MIN(s1_len, s2_len))) ? false : true;
 }
+
+#ifdef CONFIG_APR_GATEWAY
+/* Verify if the topic is a gw topic or not. */
+static bool gw_topic_match(const struct mqtt_topic *topic)
+{
+	if (strings_compare(topic->topic.utf8, nct_c2g_topic_buf,
+			    topic->topic.size, nct_c2g_topic_len)
+	    && (nct_c2g_topic_len > 0)) {
+		return true;
+	}
+	return false;
+}
+#endif
 
 /* Verify if the topic is a control channel topic or not. */
 static bool control_channel_topic_match(uint32_t list_id,
@@ -314,12 +436,63 @@ static int nct_client_id_get(char *id)
 	int at_socket_fd;
 	int bytes_written;
 	int bytes_read;
+#ifndef CONFIG_APR_GATEWAY
 	char imei_buf[NRF_IMEI_LEN + 1];
+#else
+	char psk_buf[100];
+#endif
 	int ret;
 
 	at_socket_fd = nrf_socket(NRF_AF_LTE, NRF_SOCK_DGRAM, NRF_PROTO_AT);
 	__ASSERT_NO_MSG(at_socket_fd >= 0);
 
+#ifdef CONFIG_APR_GATEWAY
+	bytes_written = nrf_write(at_socket_fd, GET_PSK_ID, GET_PSK_ID_LEN);
+	__ASSERT_NO_MSG(bytes_written == GET_PSK_ID_LEN);
+	bytes_read = nrf_read(at_socket_fd, psk_buf, At_CMNG_READ_LEN);
+	__ASSERT_NO_MSG(bytes_read == At_CMNG_READ_LEN);
+
+	if (!strncmp(psk_buf, GET_PSK_ID_ERR, strlen(GET_PSK_ID_ERR))) {
+		snprintf(id, NRF_CLOUD_CLIENT_ID_LEN + 1, "%s", "no-psk-ids");
+	} else {
+/*
+ * below, we extract the 'nrf-124578' portion as the gateway_id
+ * AT%CMNG=2,16842753,4 returns:
+ * %CMNG: 16842753,
+ * 4,
+ * "0404040404040404040404040404040404040404040404040404040404040404",
+ * "nrf-124578"
+ */
+		int ofs;
+		int i;
+		int len = strlen(psk_buf);
+		char *ptr = psk_buf;
+		const char *delimiters = ",";
+
+		LOG_DBG("ID is inside this: %s", psk_buf);
+		for (i = 0; i < 3; i++) {
+			ofs = strcspn(ptr, delimiters) + 1;
+			ptr += ofs;
+			len -= ofs;
+			if (len <= 0) {
+				break;
+			}
+		}
+		if (len > 0) {
+			if (*ptr == '"') {
+				ptr++;
+			}
+			memcpy(gateway_id, ptr, NRF_CLOUD_CLIENT_ID_LEN);
+			gateway_id[NRF_CLOUD_CLIENT_ID_LEN] = 0;
+		} else {
+			snprintf(id, NRF_CLOUD_CLIENT_ID_LEN + 1, "%s",
+				 "no-psk-ids");
+		}
+		printk("Gateway ID:%s\n", gateway_id);
+
+		snprintf(id, NRF_CLOUD_CLIENT_ID_LEN + 1, "%s", gateway_id);
+	}
+#else
 	bytes_written = nrf_write(at_socket_fd, "AT+CGSN", 7);
 	__ASSERT_NO_MSG(bytes_written == 7);
 
@@ -328,6 +501,7 @@ static int nct_client_id_get(char *id)
 	imei_buf[NRF_IMEI_LEN] = 0;
 
 	snprintf(id, NRF_CLOUD_CLIENT_ID_LEN + 1, "%s%s", CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX, imei_buf);
+#endif
 
 	ret = nrf_close(at_socket_fd);
 	__ASSERT_NO_MSG(ret == 0);
@@ -338,7 +512,7 @@ static int nct_client_id_get(char *id)
 	memcpy(id, NRF_CLOUD_CLIENT_ID, NRF_CLOUD_CLIENT_ID_LEN + 1);
 #endif /* !defined(NRF_CLOUD_CLIENT_ID) */
 
-	LOG_DBG("client_id = %s", log_strdup(id));
+	LOG_INF("client_id = %s", log_strdup(id));
 
 	return 0;
 }
@@ -780,6 +954,15 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 	struct nct_dc_data dc;
 	bool event_notify = false;
 
+#ifdef CONFIG_APR_GATEWAY
+	/* TODO: resolve this in a better way, like by passing handler in
+	 * through a structure element
+	 */
+	extern u8_t gateway_handler(const struct nct_gw_data *gw_data);
+	struct nct_gw_data gw;
+	bool gateway_notify = false;
+#endif
+
 #if defined(CONFIG_AWS_FOTA)
 	err = aws_fota_mqtt_evt_handler(mqtt_client, _mqtt_evt);
 	if (err == 0) {
@@ -845,6 +1028,17 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 			evt.type = NCT_EVT_CC_RX_DATA;
 			evt.param.cc = &cc;
 			event_notify = true;
+#ifdef CONFIG_APR_GATEWAY
+		} else if (gw_topic_match(&p->message.topic)) {
+			gw.id = p->message_id;
+			gw.data.ptr = nct.payload_buf;
+			gw.data.len = p->message.payload.len;
+			gateway_notify = true;
+			LOG_DBG("gateway topic %s received id %u msg %s",
+				log_strdup(p->message.topic.topic.utf8),
+				gw.id,
+				log_strdup(nct.payload_buf));
+#endif
 		} else {
 			/* Try to match it with one of the data topics. */
 			dc.id = p->message_id;
@@ -885,7 +1079,7 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 			if (err) {
 				LOG_ERR("Failed to save session state: %d",
 					err);
-			}
+		}
 		}
 		break;
 	}
@@ -925,6 +1119,15 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 			LOG_ERR("nct_input: failed %d", err);
 		}
 	}
+
+#ifdef CONFIG_APR_GATEWAY
+	else if (gateway_notify) {
+		err = gateway_handler(&gw);
+		if (err != 0) {
+			LOG_ERR("nct_input: failed %d", err);
+		}
+	}
+#endif
 }
 
 int nct_init(void)
@@ -1049,6 +1252,14 @@ int nct_cc_connect(void)
 		.list_count = ARRAY_SIZE(nct_cc_rx_list),
 		.message_id = NCT_CC_SUBSCRIBE_ID
 	};
+
+	int i;
+
+	LOG_DBG("subscribing to:");
+	for (i = 0; i < subscription_list.list_count; i++) {
+		LOG_DBG("%d: %s", i + 1,
+			log_strdup(subscription_list.list[i].topic.utf8));
+	}
 
 	return mqtt_subscribe(&nct.client, &subscription_list);
 }
@@ -1196,6 +1407,14 @@ int nct_dc_connect(void)
 		.list_count = 1,
 		.message_id = NCT_DC_SUBSCRIBE_ID
 	};
+
+	int i;
+
+	LOG_DBG("subscribing to:");
+	for (i = 0; i < subscription_list.list_count; i++) {
+		LOG_DBG("%d: %s", i + 1,
+			log_strdup(subscription_list.list[i].topic.utf8));
+	}
 
 	return mqtt_subscribe(&nct.client, &subscription_list);
 }

--- a/west.yml
+++ b/west.yml
@@ -24,8 +24,6 @@ manifest:
       url-base: https://github.com/nrfconnect
     - name: nrfcloud
       url-base: https://github.com/nRFCloud
-    - name: origin
-      url-base: https://github.com/plskeggs
     # Third-party repository sources:
     - name: zephyrproject
       url-base: https://github.com/zephyrproject-rtos

--- a/west.yml
+++ b/west.yml
@@ -22,6 +22,10 @@ manifest:
     # NCS repositories are hosted here.
     - name: ncs
       url-base: https://github.com/nrfconnect
+    - name: nrfcloud
+      url-base: https://github.com/nRFCloud
+    - name: origin
+      url-base: https://github.com/plskeggs
     # Third-party repository sources:
     - name: zephyrproject
       url-base: https://github.com/zephyrproject-rtos
@@ -49,6 +53,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/introduction/index.html
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
+      remote: nrfcloud
       repo-path: sdk-zephyr
       revision: v2.4.0-ncs1
       import:
@@ -93,15 +98,18 @@ manifest:
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: v1.6.99-ncs1
+      remote: ncs
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr
       revision: v0.1.0-ncs1
+      remote: ncs
       path: modules/lib/mcumgr
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
       revision: v1.4.0
+      remote: ncs
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
This PR rebases two previously-reviewed commits for the LTE gateway onto the latest NCS sdk-nrf master, then adds five more commits:
- add cloud_get_id() so app can find out it's own ID
- store keepalive value in shadow to help backend track connections
- update gateway changes to use C99 types per Zephyr changes
- improve handling of persistent sessions on gateway
- remove obsolete addr_type and update BLE address in JSON to be called 'id', both per backend changes