### PR TITLE
Feature/peripheral dfu

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -128,9 +128,9 @@ static int do_fota_start(int op, const char *file_uri, int sec_tag,
 			LOG_ERR("Missing sec_tag");
 			return -EINVAL;
 		}
-		ret = fota_download_start(hostname, path, sec_tag, apn, 0);
+		ret = fota_download_start(hostname, path, sec_tag, apn, 0, NULL);
 	} else if (slm_util_cmd_casecmp(schema, SCHEMA_HTTP)) {
-		ret = fota_download_start(hostname, path, -1, apn, 0);
+		ret = fota_download_start(hostname, path, -1, apn, 0, NULL);
 	}
 
 	return ret;

--- a/drivers/gps/gps_sim/gps_sim.c
+++ b/drivers/gps/gps_sim/gps_sim.c
@@ -386,6 +386,7 @@ static int gps_sim_setup(const struct device *dev)
 	k_work_q_start(&drv_data->work_q, drv_data->work_q_stack,
 		       K_THREAD_STACK_SIZEOF(drv_data->work_q_stack),
 		       K_PRIO_PREEMPT(CONFIG_GPS_SIM_WORKQUEUE_PRIORITY));
+	k_thread_name_set(&drv_data->work_q.thread, "gpssimworkq");
 
 	return 0;
 }

--- a/ext/cjson/cJSON.c
+++ b/ext/cjson/cJSON.c
@@ -1981,10 +1981,32 @@ CJSON_PUBLIC(void) cJSON_AddItemReferenceToObject(cJSON *object, const char *str
     add_item_to_object(object, string, create_reference(item, &global_hooks), &global_hooks, false);
 }
 
+CJSON_PUBLIC(void) cJSON_AddItemReferenceToObjectCS(cJSON *object, const char *string, cJSON *item)
+{
+    if ((object == NULL) || (string == NULL))
+    {
+        return;
+    }
+
+    add_item_to_object(object, string, create_reference(item, &global_hooks), &global_hooks, true);
+}
+
 CJSON_PUBLIC(cJSON*) cJSON_AddNullToObject(cJSON * const object, const char * const name)
 {
     cJSON *null = cJSON_CreateNull();
     if (add_item_to_object(object, name, null, &global_hooks, false))
+    {
+        return null;
+    }
+
+    cJSON_Delete(null);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddNullToObjectCS(cJSON * const object, const char * const name)
+{
+    cJSON *null = cJSON_CreateNull();
+    if (add_item_to_object(object, name, null, &global_hooks, true))
     {
         return null;
     }
@@ -2005,10 +2027,34 @@ CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObject(cJSON * const object, const char * co
     return NULL;
 }
 
+CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObjectCS(cJSON * const object, const char * const name)
+{
+    cJSON *true_item = cJSON_CreateTrue();
+    if (add_item_to_object(object, name, true_item, &global_hooks, true))
+    {
+        return true_item;
+    }
+
+    cJSON_Delete(true_item);
+    return NULL;
+}
+
 CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * const name)
 {
     cJSON *false_item = cJSON_CreateFalse();
     if (add_item_to_object(object, name, false_item, &global_hooks, false))
+    {
+        return false_item;
+    }
+
+    cJSON_Delete(false_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObjectCS(cJSON * const object, const char * const name)
+{
+    cJSON *false_item = cJSON_CreateFalse();
+    if (add_item_to_object(object, name, false_item, &global_hooks, true))
     {
         return false_item;
     }
@@ -2029,10 +2075,34 @@ CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * co
     return NULL;
 }
 
+CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObjectCS(cJSON * const object, const char * const name, const cJSON_bool boolean)
+{
+    cJSON *bool_item = cJSON_CreateBool(boolean);
+    if (add_item_to_object(object, name, bool_item, &global_hooks, true))
+    {
+        return bool_item;
+    }
+
+    cJSON_Delete(bool_item);
+    return NULL;
+}
+
 CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number)
 {
     cJSON *number_item = cJSON_CreateNumber(number);
     if (add_item_to_object(object, name, number_item, &global_hooks, false))
+    {
+        return number_item;
+    }
+
+    cJSON_Delete(number_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObjectCS(cJSON * const object, const char * const name, const double number)
+{
+    cJSON *number_item = cJSON_CreateNumber(number);
+    if (add_item_to_object(object, name, number_item, &global_hooks, true))
     {
         return number_item;
     }
@@ -2053,10 +2123,34 @@ CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * 
     return NULL;
 }
 
+CJSON_PUBLIC(cJSON*) cJSON_AddStringToObjectCS(cJSON * const object, const char * const name, const char * const string)
+{
+    cJSON *string_item = cJSON_CreateString(string);
+    if (add_item_to_object(object, name, string_item, &global_hooks, true))
+    {
+        return string_item;
+    }
+
+    cJSON_Delete(string_item);
+    return NULL;
+}
+
 CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw)
 {
     cJSON *raw_item = cJSON_CreateRaw(raw);
     if (add_item_to_object(object, name, raw_item, &global_hooks, false))
+    {
+        return raw_item;
+    }
+
+    cJSON_Delete(raw_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddRawToObjectCS(cJSON * const object, const char * const name, const char * const raw)
+{
+    cJSON *raw_item = cJSON_CreateRaw(raw);
+    if (add_item_to_object(object, name, raw_item, &global_hooks, true))
     {
         return raw_item;
     }
@@ -2077,10 +2171,34 @@ CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * 
     return NULL;
 }
 
+CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObjectCS(cJSON * const object, const char * const name)
+{
+    cJSON *object_item = cJSON_CreateObject();
+    if (add_item_to_object(object, name, object_item, &global_hooks, true))
+    {
+        return object_item;
+    }
+
+    cJSON_Delete(object_item);
+    return NULL;
+}
+
 CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name)
 {
     cJSON *array = cJSON_CreateArray();
     if (add_item_to_object(object, name, array, &global_hooks, false))
+    {
+        return array;
+    }
+
+    cJSON_Delete(array);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObjectCS(cJSON * const object, const char * const name)
+{
+    cJSON *array = cJSON_CreateArray();
+    if (add_item_to_object(object, name, array, &global_hooks, true))
     {
         return array;
     }

--- a/ext/cjson/cJSON.h
+++ b/ext/cjson/cJSON.h
@@ -218,10 +218,6 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char **strings, int count);
 /* Append item to the specified array/object. */
 CJSON_PUBLIC(void) cJSON_AddItemToArray(cJSON *array, cJSON *item);
 CJSON_PUBLIC(void) cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item);
-/* Use this when string is definitely const (i.e. a literal, or as good as), and will definitely survive the cJSON object.
- * WARNING: When this function was used, make sure to always check that (item->type & cJSON_StringIsConst) is zero before
- * writing to `item->string` */
-CJSON_PUBLIC(void) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item);
 /* Append reference to item to the specified array/object. Use this when you want to add an existing cJSON to a new cJSON, but don't want to corrupt your existing cJSON. */
 CJSON_PUBLIC(void) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item);
 CJSON_PUBLIC(void) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item);
@@ -267,6 +263,21 @@ CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * 
 CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw);
 CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name);
 CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name);
+
+/* Use this when string is definitely const (i.e. a literal, or as good as), and will definitely survive the cJSON object.
+ * WARNING: When this function was used, make sure to always check that (item->type & cJSON_StringIsConst) is zero before
+ * writing to `item->string` */
+CJSON_PUBLIC(void) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item);
+CJSON_PUBLIC(void) cJSON_AddItemReferenceToObjectCS(cJSON *object, const char *string, cJSON *item);
+CJSON_PUBLIC(cJSON*) cJSON_AddNullToObjectCS(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObjectCS(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObjectCS(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObjectCS(cJSON * const object, const char * const name, const cJSON_bool boolean);
+CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObjectCS(cJSON * const object, const char * const name, const double number);
+CJSON_PUBLIC(cJSON*) cJSON_AddStringToObjectCS(cJSON * const object, const char * const name, const char * const string);
+CJSON_PUBLIC(cJSON*) cJSON_AddRawToObjectCS(cJSON * const object, const char * const name, const char * const raw);
+CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObjectCS(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObjectCS(cJSON * const object, const char * const name);
 
 /* When assigning an integer value, it needs to be propagated to valuedouble too. */
 #define cJSON_SetIntValue(object, number) ((object) ? (object)->valueint = (object)->valuedouble = (number) : (number))

--- a/include/dfu/dfu_target.h
+++ b/include/dfu/dfu_target.h
@@ -15,6 +15,8 @@
  */
 
 #include <zephyr/types.h>
+#include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,6 +24,7 @@ extern "C" {
 
 #define DFU_TARGET_IMAGE_TYPE_MCUBOOT 1
 #define DFU_TARGET_IMAGE_TYPE_MODEM_DELTA 2
+#define DFU_TARGET_IMAGE_TYPE_PERIPHERAL 3
 
 enum dfu_target_evt_id {
 	DFU_TARGET_EVT_TIMEOUT,
@@ -51,6 +54,17 @@ struct dfu_target {
  *	   code identicating reason of failure.
  **/
 int dfu_target_img_type(const void *const buf, size_t len);
+
+/**
+ * @brief Finds the image type given a string name
+ * @details Some updates cannot be identified by their header, such as
+ *			peripheral updates
+ *
+ * @param type[in] Type name string from the Job Document
+ * @return 0 if the image could not be identified by the string, else the
+ *			supported image type number
+ */
+int dfu_target_img_type_from_string(const char *type);
 
 /**
  * @brief Initialize the resources needed for the specific image type DFU

--- a/include/dfu/dfu_target_peripheral.h
+++ b/include/dfu/dfu_target_peripheral.h
@@ -1,0 +1,64 @@
+#ifndef DFU_TARGET_PERIPHERAL_H_
+#define DFU_TARGET_PERIPHERAL_H_
+
+#include "dfu/dfu_target.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/**
+ * @brief Initialize the resources needed for the specific image type DFU
+ *	  target.
+ *
+ *	  If a target update is in progress, and the same target is
+ *	  given as input, then calling the 'init()' function of that target is
+ *	  skipped.
+ *
+ *	  To allow continuation of an aborted DFU procedure, call the
+ *	  'dfu_target_offset_get' function after invoking this function.
+ *
+ * @param[in] img_type Image type identifier.
+ * @param[in] file_size Size of the current file being downloaded.
+ * @param[in] cb Callback function in case the DFU operation requires additional
+ *		 proceedures to be called.
+ *
+ * @return 0 for a supported image type or a negative error
+ *	   code identicating reason of failure.
+ *
+ **/
+int dfu_target_peripheral_init(size_t file_size, dfu_target_callback_t cb);
+
+/**
+ * @brief Get offset of the firmware upgrade
+ *
+ * @param[out] offset Returns the offset of the firmware upgrade.
+ *
+ * @return 0 if success, otherwise negative value if unable to get the offset
+ */
+int dfu_target_peripheral_offset_get(size_t *offset);
+
+/**
+ * @brief Write the given buffer to the initialized DFU target.
+ *
+ * @param[in] buf A buffer of bytes which contains part of an binary firmware
+ *		  image.
+ * @param[in] len The length of the provided buffer.
+ *
+ * @return Positive identifier for a supported image type or a negative error
+ *	   code identicating reason of failure.
+ **/
+int dfu_target_peripheral_write(const void *const buf, size_t len);
+
+/**
+ * @brief Deinitialize the resources that were needed for the current DFU
+ *	  target.
+ *
+ * @param[in] successful Indicate whether the process completed successfully or
+ *			 was aborted.
+ *
+ * @return 0 for an successful deinitialization or a negative error
+ *	   code identicating reason of failure.
+ **/
+int dfu_target_peripheral_done(bool successful);
+
+#endif /* DFU_TARGET_PERIPHERAL_H_ */

--- a/include/net/cloud.h
+++ b/include/net/cloud.h
@@ -185,6 +185,8 @@ struct cloud_api {
 				size_t list_count);
 	int (*user_data_set)(const struct cloud_backend *const backend,
 			     void *user_data);
+	int (*get_id)(const struct cloud_backend *const backend,
+		      char *id, size_t id_len);
 };
 
 /**@brief Structure for cloud backend configuration. */
@@ -411,6 +413,25 @@ static inline int cloud_user_data_set(struct cloud_backend *const backend,
 	}
 
 	return backend->api->user_data_set(backend, user_data);
+}
+
+/**@brief Get the id string for the current device.
+ *
+ * @param backend	Pointer to cloud backend structure.
+ * @param id		Pointer to buffer to receive ID.
+ * @param id_len	Size of buffer.
+ * @return 0 on success otherwise error number.
+ */
+static inline int cloud_get_id(const struct cloud_backend *const backend,
+		      char *id, size_t id_len)
+{
+	if (backend == NULL || backend->api == NULL ||
+	    backend->api->get_id == NULL || id == NULL ||
+	    id_len == 0) {
+		return -ENOTSUP;
+	}
+
+	return backend->api->get_id(backend, id, id_len);
 }
 
 /**

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -97,13 +97,14 @@ int fota_download_init(fota_download_callback_t client_callback);
  * @param apn Access Point Name to use or NULL to use the default APN.
  * @param fragment_size Fragment size to be used for the download.
  *			If 0, @option{CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE} is used.
+ * @param type Optional update type hint
  *
  * @retval 0	     If download has started successfully.
  * @retval -EALREADY If download is already ongoing.
  *                   Otherwise, a negative value is returned.
  */
 int fota_download_start(const char *host, const char *file, int sec_tag,
-			const char *apn, size_t fragment_size);
+			const char *apn, size_t fragment_size, const char *type);
 
 #ifdef __cplusplus
 }

--- a/samples/nrf9160/http_update/application_update/src/main.c
+++ b/samples/nrf9160/http_update/application_update/src/main.c
@@ -40,7 +40,7 @@ static void update_start(void)
 	char *apn = NULL;
 
 	err = fota_download_start(CONFIG_DOWNLOAD_HOST, CONFIG_DOWNLOAD_FILE,
-				  SEC_TAG, apn, 0);
+				  SEC_TAG, apn, 0, NULL);
 	if (err != 0) {
 		update_sample_done();
 		printk("fota_download_start() failed, err %d\n", err);

--- a/samples/nrf9160/http_update/modem_delta_update/src/main.c
+++ b/samples/nrf9160/http_update/modem_delta_update/src/main.c
@@ -78,7 +78,7 @@ void update_start(void)
 
 	/* Functions for getting the host and file */
 	err = fota_download_start(CONFIG_DOWNLOAD_HOST, get_file(), SEC_TAG,
-				  apn, 0);
+				  apn, 0, NULL);
 	if (err != 0) {
 		update_sample_done();
 		printk("fota_download_start() failed, err %d\n", err);

--- a/subsys/bluetooth/gatt_dm.c
+++ b/subsys/bluetooth/gatt_dm.c
@@ -650,6 +650,7 @@ int bt_gatt_dm_continue(struct bt_gatt_dm *dm, void *context)
 	if (err) {
 		LOG_ERR("Discover failed, error: %d.", err);
 		atomic_clear_bit(dm->state_flags, STATE_ATTRS_LOCKED);
+		discovery_complete_error(dm, err);
 	}
 
 	return err;

--- a/subsys/debug/cpu_load/cpu_load.c
+++ b/subsys/debug/cpu_load/cpu_load.c
@@ -232,7 +232,9 @@ uint32_t cpu_load_get(void)
 
 	total_us = ((uint64_t)total_cyc * 1000000) /
 		    sys_clock_hw_cycles_per_sec();
-	__ASSERT(total_us < UINT32_MAX, "Measurement is limited.");
+	if (total_us >= UINT32_MAX) {
+		return 0;
+	}
 
 	/* Because of different clock sources for system clock and TIMER it
 	 * is possible that sleep time is bigger than total measured time.

--- a/subsys/dfu/dfu_target/CMakeLists.txt
+++ b/subsys/dfu/dfu_target/CMakeLists.txt
@@ -20,3 +20,6 @@ zephyr_library_sources_ifdef(CONFIG_DFU_TARGET_MODEM_DELTA
 zephyr_library_sources_ifdef(CONFIG_DFU_TARGET_MCUBOOT
   src/dfu_target_mcuboot.c
   )
+zephyr_library_sources_ifdef(CONFIG_DFU_TARGET_PERIPHERAL
+  src/dfu_target_peripheral.c
+  )

--- a/subsys/dfu/dfu_target/Kconfig
+++ b/subsys/dfu/dfu_target/Kconfig
@@ -71,6 +71,25 @@ config DFU_TARGET_MODEM_TIMEOUT
 
 endif # DFU_TARGET_MODEM_DELTA
 
+config DFU_TARGET_PERIPHERAL
+	bool "Peripheral update support"
+	default n
+	depends on UART_CONSOLE
+	select BASE64
+	select CJSON_LIB
+	help
+	  Enable support for updates that target a peripheral processor over UART
+
+if (DFU_TARGET_PERIPHERAL)
+
+config DFU_TARGET_PERIPHERAL_UART_NAME
+	string "Peripheral DFU UART name"
+	default "UART_0"
+	help
+	  UART device name to communicate with the peripheral processor with
+
+endif # DFU_TARGET_PERIPHERAL
+
 module=DFU_TARGET
 module-dep=LOG
 module-str=Device Firmware Upgrade

--- a/subsys/dfu/dfu_target/src/dfu_target_peripheral.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_peripheral.c
@@ -1,0 +1,468 @@
+#include "dfu/dfu_target_peripheral.h"
+
+#include <zephyr.h>
+#include <device.h>
+#include <drivers/uart.h>
+#include <logging/log.h>
+
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <cJSON.h>
+#include <cJSON_os.h>
+#include <sys/base64.h>
+
+LOG_MODULE_REGISTER(dfu_target_peripheral, CONFIG_DFU_TARGET_LOG_LEVEL);
+
+#define DFU_MAGIC_LEN (8u)
+#define DFU_MAGIC "XoPU24Tk"
+
+#define DFU_PACKET_HEADER_LEN (DFU_MAGIC_LEN + 6u)
+#define DFU_HEADER_FMT (DFU_MAGIC " %04d %s\n")
+
+#define DFU_MAX_CHUNK_LEN (128u)
+
+#define DFU_JSON_MAX_B64_DATA_LEN (4u * (DFU_MAX_CHUNK_LEN / 3u) + 20u)
+#define DFU_JSON_MAX_LEN (DFU_JSON_MAX_B64_DATA_LEN + 100u)
+
+#define DFU_PACKET_MAX_BUFFER_LEN                                              \
+	(DFU_PACKET_HEADER_LEN + DFU_JSON_MAX_LEN + 2u)
+
+#define CMD_START_DFU (7u)
+#define CMD_RESTART_DFU (8u)
+#define CMD_DFU_DATA (9u)
+
+/* Local buffers */
+static char json_str[DFU_JSON_MAX_LEN];
+static uint8_t b64_buffer[DFU_JSON_MAX_B64_DATA_LEN];
+static uint8_t pkt_buffer[DFU_PACKET_MAX_BUFFER_LEN];
+static size_t pkt_buffer_len;
+
+/* DFU state */
+static size_t dfu_chunk_size = DFU_MAX_CHUNK_LEN;
+static size_t dfu_msg_count;
+static size_t dfu_image_len;
+static size_t dfu_next_msg_id;
+static size_t dfu_bytes_sent;
+static dfu_target_callback_t dfu_callback;
+
+static uint8_t chunk_buffer[DFU_MAX_CHUNK_LEN];
+static size_t chunk_buffer_len;
+
+/* UART driver */
+static const struct device *uart_dev;
+
+static volatile bool rx_processing_enabled;
+K_SEM_DEFINE(response_sem, 0, 1);
+
+/*
+ * Packet structure:
+ *     magic str "XoPU24Tk"
+ *     \x20 'sp'
+ *     JSON length (4 character string)
+ *     \x20 'sp'
+ *     JSON data
+ *     \x0a '\n'
+ */
+static int send_pkt(const uint8_t *json_data, size_t len)
+{
+	int olen = snprintf((char *)pkt_buffer, sizeof(pkt_buffer) - 1,
+			    DFU_HEADER_FMT, (int)len, (const char *)json_data);
+
+	if (olen >= (sizeof(pkt_buffer) - 1)) {
+		return -ENOMEM;
+	}
+
+	for (size_t i = 0; i < olen; i++) {
+		uart_poll_out(uart_dev, pkt_buffer[i]);
+	}
+
+	return 0;
+}
+
+/*
+ * {
+ *     "cmd":CMD_START_DFU,
+ *     "file_size":250000,     // bytes
+ *     "max_chunk_size":2048,  // bytes
+ *     "version":"1.0.0",      // string
+ *     "total_msg_count":245   // Number of messages expected
+ * }
+ */
+static int send_dfu_start_pkt(size_t file_size, size_t max_chunk_size,
+			      uint32_t app_version, size_t total_msg_count)
+{
+	cJSON *obj = cJSON_CreateObject();
+
+	cJSON_AddNumberToObject(obj, "cmd", CMD_START_DFU);
+	cJSON_AddNumberToObject(obj, "file_size", file_size);
+	cJSON_AddNumberToObject(obj, "max_chunk_size", max_chunk_size);
+	cJSON_AddStringToObject(obj, "version", "1.0.0.0");
+	cJSON_AddNumberToObject(obj, "total_msg_count", total_msg_count);
+
+	if (!cJSON_PrintPreallocated(obj, json_str, sizeof(json_str), false)) {
+		cJSON_Delete(obj);
+		return -ENOMEM;
+	}
+
+	cJSON_Delete(obj);
+	return send_pkt((const uint8_t *)json_str, strlen(json_str));
+}
+
+/*
+ * {
+ *     "cmd":CMD_DFU_DATA,
+ *     "msg_id":145,               // ID of the message
+ *     "chunk_size":2048,          // bytes
+ *     "data":"BASE64ENCODEDDATA"  // String
+ * }
+ */
+static int send_dfu_data_pkt(size_t message_id, size_t chunk_size,
+			     const uint8_t *data, size_t data_len)
+{
+	cJSON *obj = cJSON_CreateObject();
+
+	cJSON_AddNumberToObject(obj, "cmd", CMD_DFU_DATA);
+	cJSON_AddNumberToObject(obj, "msg_id", message_id);
+	cJSON_AddNumberToObject(obj, "chunk_size", chunk_size);
+
+	{
+		size_t olen = 0;
+		int ret = base64_encode(b64_buffer, sizeof(b64_buffer), &olen,
+					data, data_len);
+		if (ret != 0) {
+			LOG_ERR("***Failed to b64 encode data");
+			LOG_ERR("***B64 needed %d, have %d", (int)olen,
+				(int)sizeof(b64_buffer));
+			cJSON_Delete(obj);
+			return -ENOMEM;
+		}
+
+		cJSON_AddStringToObject(obj, "data", (const char *)b64_buffer);
+	}
+
+	if (!cJSON_PrintPreallocated(obj, json_str, sizeof(json_str), false)) {
+		LOG_ERR("Failed to serialize JSON");
+		cJSON_Delete(obj);
+		return -ENOMEM;
+	}
+
+	cJSON_Delete(obj);
+	return send_pkt((const uint8_t *)json_str, strlen(json_str));
+}
+
+static inline void start_rx_processing(void)
+{
+	/* Let the UART handler start looking for a packet*/
+	k_sem_reset(&response_sem);
+	pkt_buffer_len = 0;
+	rx_processing_enabled = true;
+}
+
+static int wait_for_dfu_resp(k_timeout_t timeout)
+{
+	int rc = -1;
+
+	/*
+	 * Wait for the UART handler to receive a full message into pkt_buffer
+	 */
+	if (k_sem_take(&response_sem, timeout) == 0) {
+		/*
+		 * We don't need to look in the message. Since we got a
+		 * response, we know the peripheral had no issues with the
+		 * message was sent
+		 */
+
+		pkt_buffer_len = 0;
+		rc = 0;
+	}
+
+	rx_processing_enabled = false;
+	return rc;
+}
+
+static inline void trim_pkt_buffer(size_t idx)
+{
+	if (idx >= pkt_buffer_len) {
+		pkt_buffer_len = 0u;
+	} else if (idx > 0) {
+		pkt_buffer_len = pkt_buffer_len - idx;
+		memmove(pkt_buffer, pkt_buffer + idx, pkt_buffer_len);
+	}
+}
+
+static inline void uart_rx_handler(uint8_t character)
+{
+	/* Don't process the character if we are not expecting a response */
+	if (!rx_processing_enabled) {
+		return;
+	}
+
+	pkt_buffer[pkt_buffer_len] = character;
+	pkt_buffer_len += 1;
+
+	do {
+		/* Find the header, throw away other characters */
+		if (pkt_buffer_len < DFU_PACKET_HEADER_LEN) {
+			break;
+		}
+
+		bool has_header = false;
+		do {
+			has_header = (memcmp(pkt_buffer, DFU_MAGIC,
+						  DFU_MAGIC_LEN) == 0);
+			if (!has_header) {
+				trim_pkt_buffer(1);
+			}
+		} while ((!has_header) &&
+			 (pkt_buffer_len >= DFU_PACKET_HEADER_LEN));
+
+		if (!has_header) {
+			break;
+		}
+
+		/* We have a header, read out the length */
+		size_t json_len = 0u;
+		{
+			char len_str[5];
+			memcpy(len_str, &pkt_buffer[DFU_MAGIC_LEN + 1], 4);
+			len_str[4] = '\0';
+
+			long raw_len = strtol(len_str, NULL, 10);
+			if ((raw_len == 0) || (raw_len > DFU_JSON_MAX_LEN)) {
+				/*
+				 * Invalid length field, thrown the
+				 * mysteriously matching magic string
+				 */
+				trim_pkt_buffer(DFU_MAGIC_LEN);
+				continue;
+			}
+			json_len = (size_t)raw_len;
+		}
+
+		size_t pkt_len = json_len + DFU_PACKET_HEADER_LEN;
+		if (pkt_buffer_len < pkt_len) {
+			/* Not enough bytes to extract the JSON data */
+			break;
+		}
+
+		/*
+		 * Complete response has been received. Trim the buffer to
+		 * length and let the response parser know
+		 */
+		pkt_buffer_len = pkt_len;
+		k_sem_give(&response_sem);
+
+	} while (0);
+}
+
+static void uart_isr(const struct device *dev, void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	uart_irq_update(dev);
+
+	if (!uart_irq_rx_ready(dev)) {
+		return;
+	}
+
+	uint8_t character;
+
+	while (uart_fifo_read(dev, &character, 1)) {
+		uart_rx_handler(character);
+	}
+}
+
+int dfu_target_peripheral_init(size_t file_size, dfu_target_callback_t cb)
+{
+	LOG_INF("Starting peripheral DFU");
+
+	dfu_chunk_size = DFU_MAX_CHUNK_LEN;
+
+	dfu_msg_count = (file_size / dfu_chunk_size);
+	if ((file_size % dfu_chunk_size) > 0) {
+		dfu_msg_count += 1u;
+	}
+
+	dfu_image_len = file_size;
+
+	dfu_next_msg_id = 0u;
+	dfu_bytes_sent = 0u;
+
+	dfu_callback = cb;
+
+	chunk_buffer_len = 0u;
+
+	/* Send the start packet */
+	start_rx_processing();
+	int rc = send_dfu_start_pkt(dfu_image_len, dfu_chunk_size, 0,
+				    dfu_msg_count);
+
+	if (rc != 0) {
+		LOG_ERR("Failed to send start packet");
+		return rc;
+	}
+
+	if (wait_for_dfu_resp(K_MSEC(5000)) != 0) {
+		LOG_ERR("No response to CMD_START_DFU");
+		dfu_callback(DFU_TARGET_EVT_TIMEOUT);
+		return -EIO;
+	}
+
+	dfu_callback(DFU_TARGET_EVT_ERASE_DONE);
+	return 0;
+}
+
+int dfu_target_peripheral_offset_get(size_t *offset)
+{
+	*offset = dfu_bytes_sent + chunk_buffer_len;
+	return 0;
+}
+
+int dfu_target_peripheral_write(const void *const buf, size_t len)
+{
+	const uint8_t *buf_ptr = buf;
+
+	do {
+		size_t bytes_to_copy = dfu_chunk_size - chunk_buffer_len;
+		if (len < bytes_to_copy) {
+			bytes_to_copy = len;
+		}
+		memcpy(chunk_buffer + chunk_buffer_len, buf_ptr,
+			bytes_to_copy);
+		chunk_buffer_len += bytes_to_copy;
+		buf_ptr += bytes_to_copy;
+		len -= bytes_to_copy;
+
+		bool is_last =
+			(dfu_image_len <= (dfu_bytes_sent + chunk_buffer_len));
+
+		if (is_last || (chunk_buffer_len >= dfu_chunk_size)) {
+			LOG_INF("Sending [%d:%d] of %d bytes",
+				(int)dfu_bytes_sent,
+				(int)dfu_bytes_sent + chunk_buffer_len - 1,
+				(int)dfu_image_len);
+
+			start_rx_processing();
+			int rc = send_dfu_data_pkt(dfu_next_msg_id,
+						   dfu_chunk_size,
+						   chunk_buffer,
+						   chunk_buffer_len);
+			dfu_bytes_sent += chunk_buffer_len;
+			chunk_buffer_len = 0;
+
+			if (rc != 0) {
+				LOG_ERR("Failed to send DFU data");
+				return rc;
+			}
+
+			if (is_last) {
+				/*
+				 * If this was the last message (chunk size
+				 * aligned with the image size), then no
+				 * response will be sent by the peripheral
+				 * device
+				 */
+				LOG_INF("Last packet sent");
+			} else if (wait_for_dfu_resp(K_MSEC(1000)) != 0) {
+				LOG_ERR("No response to CMD_DFU_DATA");
+				dfu_callback(DFU_TARGET_EVT_TIMEOUT);
+				return -EIO;
+			}
+
+			dfu_next_msg_id += 1u;
+		}
+
+	} while (len > 0);
+
+	return 0;
+}
+
+int dfu_target_peripheral_done(bool successful)
+{
+	int rc = 0;
+
+	if (!successful) {
+		/* Don't bother flushing the chunk buffer */
+		LOG_INF("Peripheral DFU done, unsuccessful");
+	} else {
+		if (chunk_buffer_len > 0) {
+			/* Final packet */
+			LOG_INF("Peripheral DFU sending last packet");
+
+			rc = send_dfu_data_pkt(dfu_next_msg_id, dfu_chunk_size,
+					       chunk_buffer, chunk_buffer_len);
+			if (rc != 0) {
+				LOG_ERR("Failed to send final packet");
+				dfu_callback(DFU_TARGET_EVT_TIMEOUT);
+				return rc;
+			}
+
+			/* There is no final response message */
+			k_sleep(K_MSEC(1000));
+
+			dfu_next_msg_id += 1u;
+			dfu_bytes_sent += chunk_buffer_len;
+			chunk_buffer_len = 0;
+		}
+
+		if (dfu_bytes_sent < dfu_image_len) {
+			LOG_ERR("Peripheral DFU was not given all the "
+				"image data!");
+		} else {
+			LOG_INF("Peripheral DFU done, all data sent");
+		}
+	}
+
+	dfu_msg_count = 0;
+	dfu_image_len = 0;
+	dfu_next_msg_id = 0;
+	dfu_bytes_sent = 0;
+	dfu_callback = NULL;
+
+	return rc;
+}
+
+static int dfu_uart_init(const struct device *arg)
+{
+	ARG_UNUSED(arg);
+
+	uart_dev = device_get_binding(CONFIG_DFU_TARGET_PERIPHERAL_UART_NAME);
+	if (uart_dev == NULL) {
+		LOG_ERR("Cannot bind %s\n",
+			CONFIG_DFU_TARGET_PERIPHERAL_UART_NAME);
+		return -EINVAL;
+	}
+
+	int err;
+	uint8_t dummy;
+	uint32_t start_time = k_uptime_get_32();
+
+	/* Wait for the UART line to become valid */
+	do {
+		err = uart_err_check(uart_dev);
+		if (err) {
+			if (k_uptime_get_32() - start_time > 500) {
+				LOG_ERR("UART check failed: %d. "
+					"UART initialization timed out.", err);
+				return -EIO;
+			}
+
+			LOG_INF("UART check failed: %d. "
+				"Dropping buffer and retrying.", err);
+
+			while (uart_fifo_read(uart_dev, &dummy, 1)) {
+				/* Do nothing with the data */
+			}
+			k_sleep(K_MSEC(10));
+		}
+	} while (err);
+
+	uart_irq_callback_set(uart_dev, uart_isr);
+	uart_irq_rx_enable(uart_dev);
+	return 0;
+}
+
+SYS_INIT(dfu_uart_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/subsys/net/lib/aws_fota/Kconfig
+++ b/subsys/net/lib/aws_fota/Kconfig
@@ -27,6 +27,9 @@ config AWS_FOTA_DOWNLOAD_SECURITY_TAG
 	int "Security tag to be used for downloads"
 	default -1
 
+config AWS_FOTA_TYPE_MAX_LEN
+	int "Optional type field buffer size"
+	default 16
 
 module=AWS_FOTA
 module-dep=LOG

--- a/subsys/net/lib/aws_fota/include/aws_fota_json.h
+++ b/subsys/net/lib/aws_fota/include/aws_fota_json.h
@@ -51,6 +51,8 @@ extern "C" {
  * @param[out] file_path_buf  Output buffer for the "file" field from the Job
  *			      Document
  * @param[out] version_number  Version number from the Job Execution data type.
+ * @param[out] type_buf Output buffer for the "type" field in the Job
+ *				Document
  *
  * @return 0 if the Job Execution object is empty, 1 if Job Execution object was
  *	     correctly decoded, otherwise a negative error code is returned
@@ -61,7 +63,8 @@ int aws_fota_parse_DescribeJobExecution_rsp(const char *job_document,
 					    char *job_id_buf,
 					    char *hostname_buf,
 					    char *file_path_buf,
-					    int *version_number);
+					    int *version_number,
+					    char *type_buf);
 
 /**
  * @brief Parse a Job Execution accepted response object. Returned by a call to

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -124,6 +124,19 @@ static int update_job_execution(struct mqtt_client *const client,
 	LOG_DBG("%s, state: %d, version_number: %d", __func__,
 		state, execution_version_number);
 
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+	if ((job_id == NULL) || (job_id[0] == 0)) {
+		LOG_INF("Skipping aws_jobs_update_job_execution() call");
+		struct aws_fota_event aws_fota_evt = {
+			.id = AWS_FOTA_EVT_DONE };
+
+		accepted = true;
+		callback(&aws_fota_evt);
+		LOG_INF("Job document updated with SUCCEEDED");
+		LOG_INF("Ready to reboot");
+		return 0;
+	}
+#endif
 	ret = aws_jobs_update_job_execution(client, job_id, state,
 						 NULL,
 					     execution_version_number,

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -53,6 +53,7 @@ static uint8_t payload_buf[CONFIG_AWS_FOTA_PAYLOAD_SIZE];
 static uint8_t hostname[CONFIG_AWS_FOTA_HOSTNAME_MAX_LEN];
 static uint8_t file_path[CONFIG_AWS_FOTA_FILE_PATH_MAX_LEN];
 static uint8_t job_id[AWS_JOBS_JOB_ID_MAX_LEN];
+static char update_type[CONFIG_AWS_FOTA_TYPE_MAX_LEN];
 static aws_fota_callback_t callback;
 
 /**
@@ -183,7 +184,8 @@ static int get_job_execution(struct mqtt_client *const client,
 	err = aws_fota_parse_DescribeJobExecution_rsp(payload_buf, payload_len,
 						      job_id, hostname,
 						      file_path,
-						     &execution_version_number);
+						      &execution_version_number,
+						      update_type);
 
 	if (err < 0) {
 		LOG_ERR("Error when parsing the json: %d", err);
@@ -198,6 +200,7 @@ static int get_job_execution(struct mqtt_client *const client,
 	LOG_DBG("hostname: %s", log_strdup(hostname));
 	LOG_DBG("file_path %s", log_strdup(file_path));
 	LOG_DBG("execution_version_number: %d ", execution_version_number);
+	LOG_DBG("update_type %s", log_strdup(update_type));
 
 	/* Subscribe to update topic to receive feedback on whether an
 	 * update is accepted or not.
@@ -263,7 +266,8 @@ static int job_update_accepted(struct mqtt_client *const client,
 		sec_tag = CONFIG_AWS_FOTA_DOWNLOAD_SECURITY_TAG;
 #endif
 
-		err = fota_download_start(hostname, file_path, sec_tag, apn, 0);
+		err = fota_download_start(hostname, file_path, sec_tag, apn, 0,
+					update_type);
 		if (err) {
 			LOG_ERR("Error (%d) when trying to start firmware "
 				"download", err);

--- a/subsys/net/lib/aws_fota/src/aws_fota_json.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota_json.c
@@ -61,7 +61,8 @@ int aws_fota_parse_DescribeJobExecution_rsp(const char *job_document,
 					   char *job_id_buf,
 					   char *hostname_buf,
 					   char *file_path_buf,
-					   int *execution_version_number)
+					   int *execution_version_number,
+					   char *type_buf)
 {
 	if (job_document == NULL
 	    || job_id_buf == NULL
@@ -135,6 +136,21 @@ int aws_fota_parse_DescribeJobExecution_rsp(const char *job_document,
 	} else {
 		ret = -ENODATA;
 		goto cleanup;
+	}
+
+	if (type_buf != NULL) {
+		cJSON *type = cJSON_GetObjectItemCaseSensitive(job_data,
+								"type");
+		if (cJSON_GetStringValue(type) != NULL) {
+			strncpy_nullterm(type_buf, type->valuestring,
+						CONFIG_AWS_FOTA_TYPE_MAX_LEN);
+		} else {
+			/*
+			 * This is an optional field, non-fatal if it isn't
+			 * present in the Job Document
+			 */
+			type_buf = '\0';
+		}
 	}
 
 	ret = 1;

--- a/subsys/net/lib/azure_fota/azure_fota.c
+++ b/subsys/net/lib/azure_fota/azure_fota.c
@@ -528,7 +528,7 @@ int azure_fota_msg_process(const char *const buf, size_t size)
 
 	err = fota_download_start(fota_object.host, fota_object.path,
 				  CONFIG_AZURE_FOTA_SEC_TAG,
-				  NULL, fota_object.fragment_size);
+				  NULL, fota_object.fragment_size, NULL);
 	if (err) {
 		LOG_ERR("Error (%d) when trying to start firmware download",
 			err);

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -582,7 +582,7 @@ int download_client_init(struct download_client *const client,
 				K_THREAD_STACK_SIZEOF(client->thread_stack),
 				download_thread, client, NULL, NULL,
 				K_LOWEST_APPLICATION_THREAD_PRIO, 0, K_NO_WAIT);
-
+		k_thread_name_set(client->tid, "download_thread");
 	return 0;
 }
 

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -304,7 +304,7 @@ int fota_download_start(const char *host, const char *file, int sec_tag,
 	}
 
 	if (update != NULL) {
-		LOG_INF("B1 update, selected file:\n%s", update);
+		LOG_INF("B1 update, selected file:\n%s", log_strdup(update));
 		file = update;
 	}
 #endif /* PM_S1_ADDRESS */

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
@@ -45,6 +45,14 @@ int nrf_cloud_encode_config_response(struct nrf_cloud_data const *const input,
 				     struct nrf_cloud_data *const output,
 				     bool *const has_config);
 
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+struct desired_conn;
+
+/** @brief Update desired BLE devices array */
+int nrf_cloud_update_gateway_state(struct desired_conn *desired,
+					  int num_desired);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -7,6 +7,7 @@
 #ifndef NRF_CLOUD_TRANSPORT_H__
 #define NRF_CLOUD_TRANSPORT_H__
 
+#include <stddef.h>
 #include <net/nrf_cloud.h>
 
 #ifdef __cplusplus
@@ -45,6 +46,11 @@ struct nct_cc_data {
 	struct nrf_cloud_topic topic;
 	uint32_t id;
 	enum nct_cc_opcode opcode;
+};
+
+struct nct_gw_data {
+	struct nrf_cloud_data data;
+	uint32_t id;
 };
 
 struct nct_evt {
@@ -123,8 +129,22 @@ int nct_keepalive_time_left(void);
 /**@brief Input from the cloud module. */
 int nct_input(const struct nct_evt *evt);
 
+/**@brief Retrieve the device id. */
+int nct_client_id_get(char *id, size_t id_len);
+
 /**@brief Signal to apply FOTA update. */
 void nct_apply_update(void);
+
+
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+int g2c_send(char *buffer);
+void shadow_publish(char *buffer);
+int nct_gw_subscribe(char *c2g_topic_str);
+int nct_gw_connect(void);
+void set_gw_rx_topic(char *topic_prefix);
+void set_gw_tx_topic(char *topic_prefix);
+void nct_gw_get_stage(char *cur_stage, const int cur_stage_len);
+#endif
 
 #ifdef __cplusplus
 }

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -498,6 +498,12 @@ static int api_user_data_set(const struct cloud_backend *const backend,
 	return 0;
 }
 
+static int api_get_id(const struct cloud_backend *const backend,
+		      char *id, size_t id_len)
+{
+	return nct_client_id_get(id, id_len);
+}
+
 void nrf_cloud_run(void)
 {
 	int ret;
@@ -618,7 +624,8 @@ static const struct cloud_api nrf_cloud_api = {
 	.ping = api_ping,
 	.keepalive_time_left = api_keepalive_time_left,
 	.input = api_input,
-	.user_data_set = api_user_data_set
+	.user_data_set = api_user_data_set,
+	.get_id = api_get_id
 };
 
 CLOUD_BACKEND_DEFINE(NRF_CLOUD, nrf_cloud_api);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -392,12 +392,13 @@ static int cc_rx_data_handler(const struct nct_evt *nct_evt)
 	err = nrf_cloud_decode_requested_state(payload, &new_state);
 
 	if (err) {
+#ifndef CONFIG_NRF_CLOUD_GATEWAY
 		if (!config_found) {
 			LOG_ERR("nrf_cloud_decode_requested_state Failed %d",
 				err);
 			return err;
 		}
-
+#endif
 		/* Config only, nothing else to do */
 		return 0;
 	}
@@ -439,11 +440,15 @@ static int cc_tx_ack_handler(const struct nct_evt *nct_evt)
 
 	if (nct_evt->param.data_id == PAIRING_STATUS_REPORT_ID) {
 		if (!persistent_session) {
+#ifndef CONFIG_NRF_CLOUD_GATEWAY
 			err = nct_dc_connect();
+#else
+			LOG_INF("Subscribing to c2g topic");
+			err = nct_gw_connect();
+#endif
 			if (err) {
 				return err;
 			}
-
 			nfsm_set_current_state_and_notify(STATE_DC_CONNECTING,
 							  NULL);
 		} else {
@@ -455,7 +460,6 @@ static int cc_tx_ack_handler(const struct nct_evt *nct_evt)
 			nfsm_handle_incoming_event(&nevt, STATE_DC_CONNECTING);
 		}
 	}
-
 	return 0;
 }
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -18,6 +18,10 @@
 #include <settings/settings.h>
 #include <modem/at_cmd.h>
 
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+#include "gateway.h"
+#endif
+
 #if defined(CONFIG_NRF_MODEM_LIB)
 #include <nrf_socket.h>
 #endif
@@ -42,6 +46,12 @@ LOG_MODULE_REGISTER(nrf_cloud_transport, CONFIG_NRF_CLOUD_LOG_LEVEL);
 	(sizeof(CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX) - 1 + NRF_IMEI_LEN)
 #else
 #define NRF_CLOUD_CLIENT_ID_LEN (sizeof(NRF_CLOUD_CLIENT_ID) - 1)
+#endif
+
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+#undef NRF_CLOUD_CLIENT_ID_LEN
+#define NRF_CLOUD_CLIENT_ID_LEN  10
+#define AT_CMNG_READ_LEN 97
 #endif
 
 #define NRF_CLOUD_HOSTNAME CONFIG_NRF_CLOUD_HOST_NAME
@@ -83,6 +93,19 @@ LOG_MODULE_REGISTER(nrf_cloud_transport, CONFIG_NRF_CLOUD_LOG_LEVEL);
 #define NCT_SHADOW_GET AWS "%s/shadow/get"
 #define NCT_SHADOW_GET_LEN (AWS_LEN + NRF_CLOUD_CLIENT_ID_LEN + 11)
 
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+#define GET_PSK_ID "AT%CMNG=2,16842753,4"
+#define GET_PSK_ID_LEN (sizeof(GET_PSK_ID)-1)
+#define GET_PSK_ID_ERR "ERROR"
+#define GW_TOPIC_STR_LEN 13
+#define MAX_GW_TOPIC_LEN 256
+uint8_t nct_c2g_topic_len;
+char nct_c2g_topic_buf[MAX_GW_TOPIC_LEN];
+uint8_t nct_g2c_topic_len;
+char nct_g2c_topic_buf[MAX_GW_TOPIC_LEN];
+char gateway_id[NRF_CLOUD_CLIENT_ID_LEN+1];
+#endif
+
 /* Buffer for keeping the client_id + \0 */
 static char client_id_buf[NRF_CLOUD_CLIENT_ID_LEN + 1];
 /* Buffers for keeping the topics for nrf_cloud */
@@ -110,6 +133,7 @@ static bool persistent_session;
 
 #define NCT_CC_SUBSCRIBE_ID 1234
 #define NCT_DC_SUBSCRIBE_ID 8765
+#define NCT_CG_SUBSCRIBE_ID 2525
 
 #define NCT_RX_LIST 0
 #define NCT_TX_LIST 1
@@ -274,11 +298,134 @@ static uint32_t dc_send(const struct nct_dc_data *dc_data, uint8_t qos)
 	return mqtt_publish(&nct.client, &publish);
 }
 
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+static char stage[8];
+
+void shadow_publish(char *buffer)
+{
+	struct mqtt_publish_param publish = {
+		.message.topic.qos = MQTT_QOS_1_AT_LEAST_ONCE,
+		.message.topic.topic.size = NCT_UPDATE_TOPIC_LEN,
+		.message.topic.topic.utf8 = update_topic,
+		.message.payload.data = buffer,
+		.message.payload.len = strlen(buffer),
+		.message_id = dc_get_next_message_id()
+	};
+
+	mqtt_publish(&nct.client, &publish);
+}
+
+int g2c_send(char *buffer)
+{
+	if (!nct_g2c_topic_len) {
+		return -EINVAL;
+	}
+
+	struct mqtt_publish_param publish = {
+		.message.topic.qos = MQTT_QOS_1_AT_LEAST_ONCE,
+		.message.topic.topic.size = nct_g2c_topic_len,
+		.message.topic.topic.utf8 = nct_g2c_topic_buf,
+		.message.payload.data = buffer,
+		.message.payload.len = strlen(buffer),
+		.message_id = dc_get_next_message_id()
+	};
+
+	return  mqtt_publish(&nct.client, &publish);
+}
+
+int nct_gw_subscribe(char *c2g_topic_str)
+{
+	struct mqtt_topic c2g_topic = {
+		.topic = {
+			.utf8 = c2g_topic_str,
+			.size = nct_c2g_topic_len
+		},
+		.qos = MQTT_QOS_1_AT_LEAST_ONCE
+	};
+
+	LOG_INF("nct_gw_subscribe");
+
+	const struct mqtt_subscription_list subscription_list = {
+		.list = &c2g_topic,
+		.list_count = 1,
+		.message_id = NCT_CG_SUBSCRIBE_ID
+	};
+
+	return mqtt_subscribe(&nct.client, &subscription_list);
+}
+
+int nct_gw_connect(void)
+{
+	return nct_gw_subscribe(nct_c2g_topic_buf);
+}
+
+void nct_gw_get_stage(char *cur_stage, const int cur_stage_len)
+{
+	strncpy(cur_stage, stage, cur_stage_len);
+}
+
+void set_gw_rx_topic(char *topic_prefix)
+{
+	char *end_of_stage = strchr(topic_prefix, '/');
+	int len;
+
+	if (end_of_stage) {
+		len = end_of_stage - topic_prefix;
+		if (len >= sizeof(stage)) {
+			LOG_WRN("Truncating copy of stage string length "
+				"from %d to %zd",
+				len, sizeof(stage));
+			len = sizeof(stage) - 1;
+		}
+		memcpy(stage, topic_prefix, len);
+		stage[len] = '\0';
+	}
+
+	nct_c2g_topic_len = snprintf(nct_c2g_topic_buf, MAX_GW_TOPIC_LEN,
+				 "%sgateways/%s/c2g", topic_prefix, gateway_id);
+
+	if ((nct_c2g_topic_len > 0) && (nct_c2g_topic_len < MAX_GW_TOPIC_LEN)) {
+		LOG_INF("Gateway RX Topic: %s Len: %d",
+			log_strdup(nct_c2g_topic_buf), nct_c2g_topic_len);
+	} else {
+		LOG_ERR("Gateway RX Topic not set");
+		nct_c2g_topic_len = 0;
+	}
+}
+
+void set_gw_tx_topic(char *topic_prefix)
+{
+	nct_g2c_topic_len = snprintf(nct_g2c_topic_buf, MAX_GW_TOPIC_LEN,
+				 "%sgateways/%s/g2c", topic_prefix, gateway_id);
+
+	if ((nct_g2c_topic_len > 0) && (nct_g2c_topic_len < MAX_GW_TOPIC_LEN)) {
+		LOG_INF("Gateway TX Topic: %s Len: %d",
+			log_strdup(nct_g2c_topic_buf), nct_g2c_topic_len);
+	} else {
+		LOG_ERR("Gateway TX Topic not set");
+		nct_g2c_topic_len = 0;
+	}
+}
+#endif
+
 static bool strings_compare(const char *s1, const char *s2, uint32_t s1_len,
 			    uint32_t s2_len)
 {
 	return (strncmp(s1, s2, MIN(s1_len, s2_len))) ? false : true;
 }
+
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+/* Verify if the topic is a gw topic or not. */
+static bool gw_topic_match(const struct mqtt_topic *topic)
+{
+	if (strings_compare(topic->topic.utf8, nct_c2g_topic_buf,
+			    topic->topic.size, nct_c2g_topic_len)
+	    && (nct_c2g_topic_len > 0)) {
+		return true;
+	}
+	return false;
+}
+#endif
 
 /* Verify if the topic is a control channel topic or not. */
 static bool control_channel_topic_match(uint32_t list_id,
@@ -309,11 +456,74 @@ static bool control_channel_topic_match(uint32_t list_id,
 	return false;
 }
 
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+static void gw_client_id_get(int at_socket_fd, char *id, size_t id_len)
+{
+	char psk_buf[100];
+	int bytes_written;
+	int bytes_read;
+
+	bytes_written = nrf_write(at_socket_fd, GET_PSK_ID, GET_PSK_ID_LEN);
+	__ASSERT_NO_MSG(bytes_written == GET_PSK_ID_LEN);
+	bytes_read = nrf_read(at_socket_fd, psk_buf, AT_CMNG_READ_LEN);
+	__ASSERT_NO_MSG(bytes_read == AT_CMNG_READ_LEN);
+
+	if (!strncmp(psk_buf, GET_PSK_ID_ERR, strlen(GET_PSK_ID_ERR))) {
+		snprintf(id, id_len, "no-psk-ids");
+	} else {
+/*
+ * below, we extract the 'nrf-124578' portion as the gateway_id
+ * AT%CMNG=2,16842753,4 returns:
+ * %CMNG: 16842753,
+ * 4,
+ * "0404040404040404040404040404040404040404040404040404040404040404",
+ * "nrf-124578"
+ */
+		int ofs;
+		int i;
+		int len = strlen(psk_buf);
+		char *ptr = psk_buf;
+		const char *delimiters = ",";
+
+		LOG_DBG("ID is inside this: %s", log_strdup(psk_buf));
+		for (i = 0; i < 3; i++) {
+			ofs = strcspn(ptr, delimiters) + 1;
+			ptr += ofs;
+			len -= ofs;
+			if (len <= 0) {
+				break;
+			}
+		}
+		if (len > 0) {
+			if (*ptr == '"') {
+				ptr++;
+			}
+			memcpy(gateway_id, ptr, NRF_CLOUD_CLIENT_ID_LEN);
+			gateway_id[NRF_CLOUD_CLIENT_ID_LEN] = 0;
+		} else {
+			snprintf(id, NRF_CLOUD_CLIENT_ID_LEN + 1, "%s",
+				 "no-psk-ids");
+		}
+		snprintf(id, id_len, "%s", gateway_id);
+	}
+}
+#endif
+
 /* Function to get the client id */
-static int nct_client_id_get(char *id)
+int nct_client_id_get(char *id, size_t id_len)
 {
 #if !defined(NRF_CLOUD_CLIENT_ID)
 #if defined(CONFIG_NRF_MODEM_LIB)
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+	int at_socket_fd;
+	int ret;
+
+	at_socket_fd = nrf_socket(NRF_AF_LTE, NRF_SOCK_DGRAM, NRF_PROTO_AT);
+	__ASSERT_NO_MSG(at_socket_fd >= 0);
+	gw_client_id_get(at_socket_fd, id, id_len);
+	ret = nrf_close(at_socket_fd);
+	__ASSERT_NO_MSG(ret == 0);
+#else
 	char imei_buf[CGSN_RESPONSE_LENGTH + 1];
 	int err;
 
@@ -327,11 +537,12 @@ static int nct_client_id_get(char *id)
 
 	snprintf(id, NRF_CLOUD_CLIENT_ID_LEN + 1, "%s%.*s",
 		 CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX, NRF_IMEI_LEN, imei_buf);
+#endif /* CONFIG_NRF_CLOUD_GATEWAY */
 #else
 #error Missing NRF_CLOUD_CLIENT_ID
 #endif /* defined(CONFIG_NRF_MODEM_LIB) */
 #else
-	memcpy(id, NRF_CLOUD_CLIENT_ID, NRF_CLOUD_CLIENT_ID_LEN + 1);
+	memcpy(id, NRF_CLOUD_CLIENT_ID, id_len);
 #endif /* !defined(NRF_CLOUD_CLIENT_ID) */
 
 	LOG_DBG("client_id = %s", log_strdup(id));
@@ -343,7 +554,7 @@ static int nct_topics_populate(void)
 {
 	int ret;
 
-	ret = nct_client_id_get(client_id_buf);
+	ret = nct_client_id_get(client_id_buf, sizeof(client_id_buf));
 	if (ret != 0) {
 		return ret;
 	}
@@ -760,6 +971,8 @@ int nct_mqtt_connect(void)
 static int publish_get_payload(struct mqtt_client *client, size_t length)
 {
 	if (length > sizeof(nct.payload_buf)) {
+		LOG_ERR("length specified:%zd larger than payload_buf:%zd",
+			length, sizeof(nct.payload_buf));
 		return -EMSGSIZE;
 	}
 
@@ -775,6 +988,15 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 	struct nct_cc_data cc;
 	struct nct_dc_data dc;
 	bool event_notify = false;
+
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+	/* TODO: resolve this in a better way, like by passing handler in
+	 * through a structure element
+	 */
+	extern uint8_t gateway_handler(const struct nct_gw_data *gw_data);
+	struct nct_gw_data gw;
+	bool gateway_notify = false;
+#endif
 
 #if defined(CONFIG_AWS_FOTA)
 	err = aws_fota_mqtt_evt_handler(mqtt_client, _mqtt_evt);
@@ -841,6 +1063,17 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 			evt.type = NCT_EVT_CC_RX_DATA;
 			evt.param.cc = &cc;
 			event_notify = true;
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+		} else if (gw_topic_match(&p->message.topic)) {
+			gw.id = p->message_id;
+			gw.data.ptr = nct.payload_buf;
+			gw.data.len = p->message.payload.len;
+			gateway_notify = true;
+			LOG_DBG("gateway topic %s received id %u msg %s",
+				log_strdup(p->message.topic.topic.utf8),
+				gw.id,
+				log_strdup(nct.payload_buf));
+#endif
 		} else {
 			/* Try to match it with one of the data topics. */
 			dc.id = p->message_id;
@@ -883,6 +1116,20 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 					err);
 			}
 		}
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+		if (_mqtt_evt->param.suback.message_id == NCT_CG_SUBSCRIBE_ID) {
+			evt.type = NCT_EVT_DC_CONNECTED;
+			event_notify = true;
+
+			LOG_INF("Gateway connected; saving session state");
+			/* Subscribing complete, session is now valid */
+			err = save_session_state(1);
+			if (err) {
+				LOG_ERR("Failed to save session state: %d",
+					err);
+			}
+		}
+#endif
 		break;
 	}
 	case MQTT_EVT_UNSUBACK: {
@@ -921,6 +1168,15 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 			LOG_ERR("nct_input: failed %d", err);
 		}
 	}
+
+#ifdef CONFIG_NRF_CLOUD_GATEWAY
+	else if (gateway_notify) {
+		err = gateway_handler(&gw);
+		if (err != 0) {
+			LOG_ERR("nct_input: failed %d", err);
+		}
+	}
+#endif
 }
 
 int nct_init(void)
@@ -1046,6 +1302,14 @@ int nct_cc_connect(void)
 		.message_id = NCT_CC_SUBSCRIBE_ID
 	};
 
+	int i;
+
+	LOG_DBG("subscribing to:");
+	for (i = 0; i < subscription_list.list_count; i++) {
+		LOG_DBG("%d: %s", i + 1,
+			log_strdup(subscription_list.list[i].topic.utf8));
+	}
+
 	return mqtt_subscribe(&nct.client, &subscription_list);
 }
 
@@ -1079,8 +1343,8 @@ int nct_cc_send(const struct nct_cc_data *cc_data)
 
 	publish.message_id = cc_data->id ? cc_data->id : ++msg_id;
 
-	LOG_DBG("mqtt_publish: id = %d opcode = %d len = %d", publish.message_id,
-		cc_data->opcode, cc_data->data.len);
+	LOG_DBG("mqtt_publish: id = %d opcode = %d len = %d",
+		publish.message_id, cc_data->opcode, cc_data->data.len);
 
 	int err = mqtt_publish(&nct.client, &publish);
 
@@ -1192,6 +1456,14 @@ int nct_dc_connect(void)
 		.list_count = 1,
 		.message_id = NCT_DC_SUBSCRIBE_ID
 	};
+
+	int i;
+
+	LOG_DBG("subscribing to:");
+	for (i = 0; i < subscription_list.list_count; i++) {
+		LOG_DBG("%d: %s", i + 1,
+			log_strdup(subscription_list.list[i].topic.utf8));
+	}
 
 	return mqtt_subscribe(&nct.client, &subscription_list);
 }

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -138,7 +138,7 @@ static void test_fota_download_start(void)
 	s1_version = 1;
 	expect_s0_active = false;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
+	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0, NULL);
 	zassert_equal(err, 0, NULL);
 	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
 		      "Incorrect param for s0_active");
@@ -146,7 +146,7 @@ static void test_fota_download_start(void)
 	s0_version = 2;
 	s1_version = 1;
 	expect_s0_active = true;
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
+	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0, NULL);
 	zassert_equal(err, 0, NULL);
 	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
 		      "Incorrect param for s0_active");
@@ -159,14 +159,14 @@ static void test_fota_download_start(void)
 	/* update set to null indicates to use original file param */
 	dfu_ctx_mcuboot_set_b1_file__update = NULL;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
+	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0, NULL);
 	zassert_equal(err, 0, NULL);
 	zassert_true(strcmp(download_client_start_file, S0_S1) == 0, NULL);
 
 	/* update set to not null indicates to use update for file param */
 	dfu_ctx_mcuboot_set_b1_file__update = S1;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
+	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0, NULL);
 	zassert_equal(err, 0, NULL);
 	zassert_true(strcmp(download_client_start_file, S1) == 0, NULL);
 }

--- a/west.yml
+++ b/west.yml
@@ -22,6 +22,10 @@ manifest:
     # NCS repositories are hosted here.
     - name: ncs
       url-base: https://github.com/nrfconnect
+    - name: nrfcloud
+      url-base: https://github.com/nRFCloud
+    - name: origin
+      url-base: https://github.com/plskeggs
     # Third-party repository sources:
     - name: zephyrproject
       url-base: https://github.com/zephyrproject-rtos
@@ -49,8 +53,11 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/introduction/index.html
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
+    # remote: nrfcloud
+      remote: origin
+      revision: feature-debug-improvements
       repo-path: sdk-zephyr
-      revision: 3366927a54986ad0ddf060d0e08ecc578adf11f0
+    # revision: 3366927a54986ad0ddf060d0e08ecc578adf11f0
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -94,15 +101,21 @@ manifest:
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: b95e49304a9ee82f83668d51c1d95c6f2faaf983
+      remote: ncs
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr
       revision: c811bcbd446c4589496fc96237c0a286ea2e7f10
+      remote: ncs
       path: modules/lib/mcumgr
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
       revision: 8243ed209863ee1a3bf2a5d2735a939e8f890f4f
+    #  revision: feature-large-block-fix
+    # remote: origin
+
+      remote: ncs
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
This PR adds in dfu_target_peripheral, which can send updates to the nRF52 over the same UART used for logging (USB-UART bridge)
 - Logging does not need to be disabled
 - BLE does not need to be reset into MCUBOOT to perform the update

## Limitations
I am unable to get a Job Document created to test this feature, instead I have instrumented my local application to bypass the Job Document and just start the update