### PR TITLE
give gateway access to persistent sessions flag

### DIFF
--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -145,6 +145,8 @@ void set_gw_rx_topic(char *topic_prefix);
 void set_gw_tx_topic(char *topic_prefix);
 void nct_gw_get_stage(char *cur_stage, const int cur_stage_len);
 void nct_gw_get_tenant_id(char *cur_tenant, const int cur_tenant_len);
+int get_session_state(void);
+int save_session_state(const int session_valid);
 #endif
 
 #ifdef __cplusplus

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -742,6 +742,13 @@ int save_session_state(const int session_valid)
 	return ret;
 }
 
+#if defined(CONFIG_NRF_CLOUD_GATEWAY)
+int get_session_state(void)
+{
+	return persistent_session;
+}
+#endif
+
 static int nct_settings_init(void)
 {
 	int ret = 0;


### PR DESCRIPTION
For debugging, let the shell user see the persistent sessions flag and/or modify it.